### PR TITLE
Specify ruby version in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
+ruby '2.4.1'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.0.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,5 +170,8 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
 
+RUBY VERSION
+   ruby 2.4.1p111
+
 BUNDLED WITH
    1.15.1


### PR DESCRIPTION
This is needed in order to ensure consistent behavior across different
dev environments. Furthermore, this is needed once we deploy our app to
Heroku.