### PR TITLE
Admin creates a sequence

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem 'jbuilder', '~> 2.5'
 
 group :development, :test do
   gem 'rspec-rails', '~> 3.5'
+  gem 'factory_girl_rails'
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri
 end

--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,12 @@ group :development do
   gem 'spring-watcher-listen', '~> 2.0.0'
 end
 
-gem 'capybara', group: :test
+group :test do
+  gem 'capybara'
+  gem 'shoulda-matchers',
+    git: 'https://github.com/thoughtbot/shoulda-matchers.git',
+    branch: 'rails-5'
+end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,11 @@ GEM
     diff-lcs (1.3)
     erubis (2.7.0)
     execjs (2.7.0)
+    factory_girl (4.8.0)
+      activesupport (>= 3.0.0)
+    factory_girl_rails (4.8.0)
+      factory_girl (~> 4.8.0)
+      railties (>= 3.0.0)
     ffi (1.9.18)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
@@ -195,6 +200,7 @@ DEPENDENCIES
   byebug
   capybara
   coffee-rails (~> 4.2)
+  factory_girl_rails
   jbuilder (~> 2.5)
   jquery-rails
   listen (~> 3.0.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/thoughtbot/shoulda-matchers.git
+  revision: ead87017a6c15adce66a87dce8ee2ece91d0d27c
+  branch: rails-5
+  specs:
+    shoulda-matchers (3.1.2)
+      activesupport (>= 4.0.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -194,6 +202,7 @@ DEPENDENCIES
   rails (~> 5.0.4)
   rspec-rails (~> 3.5)
   sass-rails (~> 5.0)
+  shoulda-matchers!
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3

--- a/app/controllers/sequences_controller.rb
+++ b/app/controllers/sequences_controller.rb
@@ -1,0 +1,28 @@
+class SequencesController < ApplicationController
+  def index
+  end
+
+  def new
+    sequence = Sequence.new
+
+    render "sequences/new", locals: { sequence: sequence }
+  end
+
+  def create
+    sequence = Sequence.create(sequence_params)
+
+    redirect_to sequence
+  end
+
+  def show
+    sequence = Sequence.find(params[:id])
+
+    render "sequences/show", locals: { sequence: sequence }
+  end
+
+  private
+
+  def sequence_params
+    params.require(:sequence).permit(:name)
+  end
+end

--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -1,0 +1,2 @@
+class Sequence < ApplicationRecord
+end

--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -1,2 +1,3 @@
 class Sequence < ApplicationRecord
+  validates :name, presence: true
 end

--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -1,3 +1,3 @@
 class Sequence < ApplicationRecord
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: true
 end

--- a/app/views/sequences/index.html.erb
+++ b/app/views/sequences/index.html.erb
@@ -1,0 +1,3 @@
+<h1>Sequences</h1>
+
+<%= link_to "New Sequence", new_sequence_path %>

--- a/app/views/sequences/new.html.erb
+++ b/app/views/sequences/new.html.erb
@@ -1,0 +1,5 @@
+<%= form_for sequence do |f| %>
+  <%= f.label :name %>
+  <%= f.text_field :name %>
+  <%= f.submit "Create" %>
+<% end %>

--- a/app/views/sequences/show.html.erb
+++ b/app/views/sequences/show.html.erb
@@ -1,0 +1,1 @@
+<h1><%= sequence.name %></h1>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  resources :sequences, only: [:new, :create, :show]
+
+  root "sequences#index"
 end

--- a/db/migrate/20170628005626_create_sequence.rb
+++ b/db/migrate/20170628005626_create_sequence.rb
@@ -1,0 +1,11 @@
+class CreateSequence < ActiveRecord::Migration[5.0]
+  def change
+    create_table :sequences do |t|
+      t.string :name, null: false
+
+      t.timestamps
+
+      t.index :name, unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,22 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 20170628005626) do
+
+  create_table "sequences", force: :cascade do |t|
+    t.string   "name",       null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_sequences_on_name", unique: true
+  end
+
+end

--- a/spec/factories/sequence.rb
+++ b/spec/factories/sequence.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :sequence do
+    name "How to Learn Music"
+  end
+end

--- a/spec/features/admin_creates_a_sequence_spec.rb
+++ b/spec/features/admin_creates_a_sequence_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+feature "Admin creates a sequence" do
+  scenario "successfully" do
+    visit root_path
+    click_link "New Sequence"
+    fill_in "Name", with: "Play Music in 7 days"
+    click_button "Create"
+
+    expect(page).to have_content "Play Music in 7 days"
+  end
+end

--- a/spec/models/sequence_spec.rb
+++ b/spec/models/sequence_spec.rb
@@ -1,0 +1,7 @@
+require "rails_helper"
+
+describe Sequence do
+  describe "validations" do
+    it { should validate_presence_of(:name) }
+  end
+end

--- a/spec/models/sequence_spec.rb
+++ b/spec/models/sequence_spec.rb
@@ -2,6 +2,8 @@ require "rails_helper"
 
 describe Sequence do
   describe "validations" do
+    subject { build(:sequence) }
     it { should validate_presence_of(:name) }
+    it { should validate_uniqueness_of(:name) }
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -55,6 +55,8 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.include FactoryGirl::Syntax::Methods
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,5 +63,6 @@ Shoulda::Matchers.configure do |config|
   config.integrate do |with|
     with.test_framework :rspec
     with.library :active_model
+    with.library :active_record
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -56,3 +56,10 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :active_model
+  end
+end


### PR DESCRIPTION
# Description
Allow an admin to create a sequence. A sequence is simply created by filling out its name.

# Solution
- Add a `Sequence` model with `presence` and `uniqueness` validations attached to `name`. Respective db constraints were also added.
- Add a `SequenceController` with `new`, `create`, and `show` actions. Code within these actions are standard, and doesn't go away from the Rails conventions. Respective views were added to these actions.

# GIF
![Admin creates a Sequence](https://media.giphy.com/media/3o7buauox9Y7T67kYw/giphy.gif)

# Notes
- In order to test the presence and uniqueness validations, I opted to add two gems `factory_girl` and `shoulda-matchers`. For more information, please view the respective commits adding these gems.

[Commit that adds factory_girl](https://github.com/kntsoriano/sequencer/commit/f4b730452ed8139a1caf182eea797e5de7e92371)
[Commit that adds shoulda-matchers](https://github.com/kntsoriano/sequencer/commit/c5c386ca1c7ca0394b2386a2167857965f49f399)